### PR TITLE
Fix channel resubscribe typo

### DIFF
--- a/bfxapi/websockets/SubscriptionManager.py
+++ b/bfxapi/websockets/SubscriptionManager.py
@@ -91,7 +91,7 @@ class SubscriptionManager:
 
         This function is mostly used to force the channel to produce a fresh snapshot.
         """
-        sub = self.subscriptions_chanid[chan_d]
+        sub = self.subscriptions_chanid[chan_id]
 
         async def re_sub():
             await sub.subscribe()


### PR DESCRIPTION
When subscribed to a Bitfinex order book, sometimes the checksum fails but the `SubscriptionManager`'s `resubscribe` logic throws this error:

```
[BfxWebsocket] [WARNING] Checksum orderbook invalid for 'tBTCUSD'. Resetting subscription.
ERROR: name 'chan_d' is not defined
Traceback (most recent call last):
  File "bitfinex-api-py/bfxapi/websockets/GenericWebsocket.py", line 46, in run
    self.loop.run_until_complete(self._main(self.host))
  File "/anaconda3/lib/python3.6/asyncio/base_events.py", line 467, in run_until_complete
    return future.result()
  File "bitfinex-api-py/bfxapi/websockets/GenericWebsocket.py", line 61, in _main
    await self.on_message(message)
  File "bitfinex-api-py/bfxapi/websockets/BfxWebsocket.py", line 361, in on_message
    await self._ws_data_handler(msg)
  File "bitfinex-api-py/bfxapi/websockets/BfxWebsocket.py", line 164, in _ws_data_handler
    await self._order_book_handler(data)
  File "bitfinex-api-py/bfxapi/websockets/BfxWebsocket.py", line 337, in _order_book_handler
    await self.subscriptionManager.resubscribe(chan_id)
  File "bitfinex-api-py/bfxapi/websockets/SubscriptionManager.py", line 94, in resubscribe
    sub = self.subscriptions_chanid[chan_d]
NameError: name 'chan_d' is not defined
```

Looks like it's caused by a simple typo: `chan_d` should just be renamed `chan_id`.

The fix is in this pull request, hope it helps!