### PR TITLE
Support derivatives

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+1.0.1
+
+- Added ws event `status_update`
+- Added rest function `get_derivative_status`
+- Added rest function `get_derivative_statuses`
+- Added rest function `set_derivative_collateral`
+- Added channel support `status`
+
 1.0.0
 
 - Removal of camel-casing file naming and git duplicates

--- a/README.md
+++ b/README.md
@@ -227,6 +227,14 @@ Get the public orderbook of a given symbol
   Get tickers for the given symbols. Tickers shows you the current best bid and ask,
   as well as the last trade price.
 
+### `get_derivative_status(symbol)`
+
+  Get derivative platform information for the given symbol.
+
+### `get_derivative_statuses(symbols)`
+
+  Get derivative platform information for the given collection of symbols.
+
 ### `get_wallets()`
 
   Get all wallets on account associated with API_KEY - Requires authentication.
@@ -276,6 +284,10 @@ Get the public orderbook of a given symbol
 ### `get_funding_credit_history(symbol, start, end, limit=25)`
 
   Get all of the funding credits between the start and end period associated with API_KEY - Requires authentication.
+
+### `set_derivative_collateral(symbol, collateral)`
+
+  Set the amount of collateral used to back a derivative position.
 
 # Examples
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ The websocket exposes a collection of events that are triggered when certain dat
 - `order_snapshot` (array[Order]): Initial open orders (Fired once)
 - `positions_snapshot` (array): Initial open positions (Fired once)
 - `wallet_update` (Wallet): changes to the balance of wallets
+- `status_update` (json): new platform status info
 - `seed_candle` (json): initial past candle to prime strategy
 - `seed_trade` (json): initial past trade to prime strategy
 - `funding_offer_snapshot` (array): opening funding offer balances

--- a/bfxapi/examples/rest/get_authenticated_data.py
+++ b/bfxapi/examples/rest/get_authenticated_data.py
@@ -12,8 +12,7 @@ API_SECRET=os.getenv("BFX_SECRET")
 bfx = Client(
   API_KEY=API_KEY,
   API_SECRET=API_SECRET,
-  logLevel='DEBUG',
-  rest_host='https://test.bitfinex.com/v2'
+  logLevel='DEBUG'
 )
 
 now = int(round(time.time() * 1000))

--- a/bfxapi/examples/rest/get_public_data.py
+++ b/bfxapi/examples/rest/get_public_data.py
@@ -38,12 +38,18 @@ async def log_mul_tickers():
   print ("Tickers:")
   print (tickers)
 
+async def log_derivative_status():
+  status = await bfx.rest.get_derivative_status('tBTCF0:USTF0')
+  print ("Deriv status:")
+  print (status)
+
 async def run():
   await log_historical_candles()
   await log_historical_trades()
   await log_books()
   await log_ticker()
   await log_mul_tickers()
+  await log_derivative_status()
   
 t = asyncio.ensure_future(run())
 asyncio.get_event_loop().run_until_complete(t)

--- a/bfxapi/examples/ws/subscribe_derivative_status.py
+++ b/bfxapi/examples/ws/subscribe_derivative_status.py
@@ -1,0 +1,23 @@
+import os
+import sys
+sys.path.append('../')
+
+from bfxapi import Client
+
+bfx = Client(
+  logLevel='INFO'
+)
+
+@bfx.ws.on('error')
+def log_error(err):
+  print ("Error: {}".format(err))
+
+@bfx.ws.on('status_update')
+def log_msg(msg):
+  print (msg)
+
+async def start():
+  await bfx.ws.subscribe_derivative_status('tBTCF0:USTF0')
+
+bfx.ws.on('connected', start)
+bfx.ws.run()

--- a/bfxapi/models/subscription.py
+++ b/bfxapi/models/subscription.py
@@ -21,13 +21,13 @@ class Subscription:
     such as unsibscribe and subscribe.
     """
 
-    def __init__(self, socket, channel_name, symbol, timeframe=None, **kwargs):
+    def __init__(self, socket, channel_name, symbol, key=None, timeframe=None, **kwargs):
         self.socket = socket
         self.channel_name = channel_name
         self.symbol = symbol
         self.timeframe = timeframe
         self.is_subscribed_bool = False
-        self.key = None
+        self.key = key
         self.chan_id = None
         if timeframe:
             self.key = 'trade:{}:{}'.format(self.timeframe, self.symbol)
@@ -79,7 +79,7 @@ class Subscription:
     def _generate_payload(self, **kwargs):
         payload = {'event': 'subscribe',
                    'channel': self.channel_name, 'symbol': self.symbol}
-        if self.timeframe:
+        if self.timeframe or self.key:
             payload['key'] = self.key
         payload.update(**kwargs)
         return payload

--- a/bfxapi/rest/__init__.py
+++ b/bfxapi/rest/__init__.py
@@ -1,0 +1,1 @@
+NAME = 'rest'

--- a/bfxapi/utils/__init__.py
+++ b/bfxapi/utils/__init__.py
@@ -1,0 +1,1 @@
+NAME = 'utils'

--- a/bfxapi/version.py
+++ b/bfxapi/version.py
@@ -2,4 +2,4 @@
 This module contains the current version of the bfxapi lib
 """
 
-__version__ = '1.0.0'
+__version__ = '1.0.1'

--- a/bfxapi/websockets/__init__.py
+++ b/bfxapi/websockets/__init__.py
@@ -1,0 +1,1 @@
+NAME = 'websockets'

--- a/bfxapi/websockets/subscription_manager.py
+++ b/bfxapi/websockets/subscription_manager.py
@@ -32,7 +32,7 @@ class SubscriptionManager:
                 count += 1
         return count
 
-    async def subscribe(self, channel_name, symbol, timeframe=None, **kwargs):
+    async def subscribe(self, channel_name, symbol, key=None, timeframe=None, **kwargs):
         """
         Subscribe to a new channel
 
@@ -51,7 +51,7 @@ class SubscriptionManager:
             socket = self.bfxapi.get_most_available_socket()
         # create a new subscription
         subscription = Subscription(
-            socket, channel_name, symbol, timeframe, **kwargs)
+            socket, channel_name, symbol, key, timeframe, **kwargs)
         self.logger.info("Subscribing to channel {}".format(channel_name))
         self.pending_subscriptions[subscription.get_key()] = subscription
 

--- a/pylint.rc
+++ b/pylint.rc
@@ -10,4 +10,4 @@ disable=too-few-public-methods,
         too-many-instance-attributes,
         invalid-name
 
-ignore=tests
+ignore=tests,websockets,rest,utils

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,76 @@
+"""A setuptools based setup module.
+See:
+https://packaging.python.org/guides/distributing-packages-using-setuptools/
+https://github.com/pypa/sampleproject
+"""
+
+# Always prefer setuptools over distutils
+from setuptools import setup, find_packages
+from os import path
+# io.open is needed for projects that support Python 2.7
+# It ensures open() defaults to text mode with universal newlines,
+# and accepts an argument to specify the text encoding
+# Python 3 only projects can skip this import
+from io import open
+
+here = path.abspath(path.dirname(__file__))
+
+# Arguments marked as "Required" below must be included for upload to PyPI.
+# Fields marked as "Optional" may be commented out.
+
+setup(
+    name='bitfinex-api-py',
+    version='1.0.1',  # Required
+    description='Official Bitfinex API',  # Optional
+    long_description='This is an official python library that is used to connect interact with the Bitfinex api.',  # Optional
+    long_description_content_type='text/markdown',  # Optional
+    url='https://github.com/bitfinexcom/bitfinex-api-py',  # Optional
+    author='Bitfinex',  # Optional
+    author_email='support@bitfinex.com',  # Optional
+    classifiers=[  # Optional
+        # How mature is this project? Common values are
+        #   3 - Alpha
+        #   4 - Beta
+        #   5 - Production/Stable
+        'Development Status :: 4 - Beta',
+
+        # Indicate who your project is intended for
+        'Intended Audience :: Developers',
+        'Topic :: Software Development :: Build Tools',
+
+        # Pick your license as you wish
+        'License :: OSI Approved :: Apache 2.0',
+
+        # Specify the Python versions you support here. In particular, ensure
+        # that you indicate whether you support Python 2, Python 3 or both.
+        # These classifiers are *not* checked by 'pip install'. See instead
+        # 'python_requires' below.
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+    ],
+
+    keywords='bitfinex',  # Optional
+
+    packages=find_packages(exclude=['examples', 'tests']),  # Required
+
+    # Specify which Python versions you support. In contrast to the
+    # 'Programming Language' classifiers above, 'pip install' will check this
+    # and refuse to install the project if the version does not match. If you
+    # do not support Python 2, you can simplify this to '>=3.5' or similar, see
+    # https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4',
+
+    # This field lists other packages that your project depends on to run.
+    # Any package you put here will be installed by pip when your project is
+    # installed, so they must be valid existing projects.
+    #
+    # For an analysis of "install_requires" vs pip's requirements files see:
+    # https://packaging.python.org/en/latest/requirements.html
+    install_requires=['eventemitter', 'asyncio', 'websockets', 'pylint', 'six', 'pyee', 'aiohttp'],  # Optional
+
+    project_urls={  # Optional
+        'Bug Reports': 'https://github.com/bitfinexcom/bitfinex-api-py/issues',
+        'Source': 'https://github.com/bitfinexcom/bitfinex-api-py',
+    },
+)


### PR DESCRIPTION
### Description:
With the release of the bitfinex derivatives engine there are some new additions such as support for new pairs long style pairs i.e DUSK:BTC, DUSK:USD, tBTCF0:USTF0 and also 3 new endpoints:
https://docs.bitfinex.com/v2/reference#status
https://docs.bitfinex.com/v2/reference#ws-public-status
https://docs.bitfinex.com/v2/reference#rest-auth-deriv-pos-collateral-set

### Breaking changes:
None

### New features:
- New ws event `status_update`
- New rest function `get_derivative_status`
- New rest function `get_derivative_statuses`
- New rest function `set_derivative_collateral`
- New channel support `status`

### Fixes:
None

### PR status:
- [x] Version bumped
- [x] Change-log updated
