### PR TITLE
Reduce CPU usage and avoid asyncio error on SSL transport

### DIFF
--- a/bfxapi/websockets/generic_websocket.py
+++ b/bfxapi/websockets/generic_websocket.py
@@ -53,7 +53,7 @@ def _start_event_worker():
         sleeping process for event emitter to schedule on
         """
         while True:
-            await asyncio.sleep(0)
+            await asyncio.sleep(.03)
     def start_loop(loop):
         asyncio.set_event_loop(loop)
         loop.run_until_complete(event_sleep_process())


### PR DESCRIPTION
### Description:
When Client is instantiated, it consumes a lot of CPU. That is because a `while True` using `sleep(0)`.
It also cause the following error:
```ERROR:asyncio:Fatal error on SSL transport
protocol: <asyncio.sslproto.SSLProtocol object at 0x7f8448121cc0>
transport: <_SelectorSocketTransport fd=13 read=polling write=<idle, bufsize=0>>
Traceback (most recent call last):
  File ".../python3.7/asyncio/sslproto.py", line 664, in _process_write_backlog
    data, offset = self._write_backlog[0]
IndexError: deque index out of range
```
I found 0.03 seconds reasonable, not consuming a lot of CPU although everything works fine.
The best solution would be allow user control the loop and threads, but I don't know how yet.

### Fixes:
- High CPU usage
- asyncio SSL error
