### PR TITLE
Fix for data server

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,8 @@
 - Added rest function `get_derivative_statuses`
 - Added rest function `set_derivative_collateral`
 - Added channel support `status`
+- Added create_event_emitter as override in generic_websocket 
+  for custom event emitters
 
 1.0.0
 

--- a/bfxapi/client.py
+++ b/bfxapi/client.py
@@ -19,11 +19,10 @@ class Client:
     """
 
     def __init__(self, API_KEY=None, API_SECRET=None, rest_host=REST_HOST,
-                 ws_host=WS_HOST, loop=None, logLevel='INFO', dead_man_switch=False,
+                 ws_host=WS_HOST, create_event_emitter=None, logLevel='INFO', dead_man_switch=False,
                  ws_capacity=25, *args, **kwargs):
-        self.loop = loop or asyncio.get_event_loop()
         self.ws = BfxWebsocket(API_KEY=API_KEY, API_SECRET=API_SECRET, host=ws_host,
-                               loop=self.loop, logLevel=logLevel, dead_man_switch=dead_man_switch,
-                               ws_capacity=ws_capacity, *args, **kwargs)
+                               logLevel=logLevel, dead_man_switch=dead_man_switch,
+                               ws_capacity=ws_capacity, create_event_emitter=create_event_emitter, *args, **kwargs)
         self.rest = BfxRest(API_KEY=API_KEY, API_SECRET=API_SECRET, host=rest_host,
-                            loop=self.loop, logLevel=logLevel, *args, **kwargs)
+                            logLevel=logLevel, *args, **kwargs)

--- a/bfxapi/tests/helpers.py
+++ b/bfxapi/tests/helpers.py
@@ -1,6 +1,7 @@
 import time
 import json
 import asyncio
+from pyee import EventEmitter
 
 from .. import Client, BfxWebsocket, Socket
 
@@ -8,7 +9,7 @@ def get_now():
 	return int(round(time.time() * 1000))
 
 def ev_worker_override():
-		return asyncio.get_event_loop()
+		return EventEmitter()
 
 class StubbedWebsocket(BfxWebsocket):
 


### PR DESCRIPTION
### Description:
The websocket multiplexer update broke the interface that the HF data server used. This PR fixes that so the HF strategy can communicate with the HF data server

### Breaking changes:
- [] You can no longer override `loop` in the constructor. But you can now override `create_event_emitter` which adds more flexibility.

### New features:
None

### Fixes:
- [x] Now works with HF dataserver

### PR status:
- [x] Change-log updated
