### PR TITLE
bfx_rest: change 'is not None' to '!= None'

### DIFF
--- a/bfxapi/rest/bfx_rest.py
+++ b/bfxapi/rest/bfx_rest.py
@@ -531,19 +531,19 @@ class BfxRest:
         flags = calculate_order_flags(hidden, close, reduce_only, post_only, oco)
         payload['flags'] = flags
         # add extra parameters
-        if price_trailing is not None:
+        if price_trailing != None:
             payload['price_trailing'] = price_trailing
-        if price_aux_limit is not None:
+        if price_aux_limit != None:
             payload['price_aux_limit'] = price_aux_limit
-        if oco_stop_price is not None:
+        if oco_stop_price != None:
             payload['price_oco_stop'] = str(oco_stop_price)
-        if time_in_force is not None:
+        if time_in_force != None:
             payload['tif'] = time_in_force
-        if gid is not None:
+        if gid != None:
             payload['gid'] = gid
-        if leverage is not None:
+        if leverage != None:
             payload['lev'] = str(leverage)
-        if aff_code is not None:
+        if aff_code != None:
             payload['meta']['aff_code'] = str(aff_code)
         endpoint = "auth/w/order/submit"
         raw_notification = await self.post(endpoint, payload)
@@ -583,19 +583,19 @@ class BfxRest:
         @param leverage: the amount of leverage to apply to the order as an integer
         """
         payload = {"id": orderId}
-        if price is not None:
+        if price != None:
             payload['price'] = str(price)
-        if amount is not None:
+        if amount != None:
             payload['amount'] = str(amount)
-        if delta is not None:
+        if delta != None:
             payload['delta'] = str(delta)
-        if price_aux_limit is not None:
+        if price_aux_limit != None:
             payload['price_aux_limit'] = str(price_aux_limit)
-        if price_trailing is not None:
+        if price_trailing != None:
             payload['price_trailing'] = str(price_trailing)
-        if time_in_force is not None:
+        if time_in_force != None:
             payload['time_in_force'] = str(time_in_force)
-        if leverage is not None:
+        if leverage != None:
             payload["lev"] = str(leverage)
         flags = calculate_order_flags(
             hidden, close, reduce_only, post_only, False)


### PR DESCRIPTION
### Description:
Python 3.8 sometimes throws linting errors when 'Is not None' is used

### Breaking changes:
- [ ]

### New features:
- [ ]

### Fixes:
- [ ]

### PR status:
- ~~Version bumped~~
- ~~Change-log updated~~
