### PR TITLE
generic_websocket: set event_emmiter thread to daemon

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+1.1.5
+- Fixes 100% CPU utilization bug with the generic_websocket event emitter thread
+
 1.1.4
 - Locks mutex when sending websocket messages
 - Fix py3.8 stricter linting errors

--- a/bfxapi/utils/custom_logger.py
+++ b/bfxapi/utils/custom_logger.py
@@ -82,6 +82,10 @@ class CustomLogger(logging.Logger):
         self.addHandler(console)
         logging.addLevelName(self.TRADE, "TRADE")
         return
+
+    def set_level(self, level):
+        logging.Logger.setLevel(self, level)
+
     
     def trade(self, message, *args, **kws):
         """

--- a/bfxapi/version.py
+++ b/bfxapi/version.py
@@ -2,4 +2,4 @@
 This module contains the current version of the bfxapi lib
 """
 
-__version__ = '1.1.0'
+__version__ = '1.1.5'

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from os import path
 here = path.abspath(path.dirname(__file__))
 setup(
     name='bitfinex-api-py',
-    version='1.1.4',
+    version='1.1.5',
     description='Official Bitfinex Python API',
     long_description='A Python reference implementation of the Bitfinex API for both REST and websocket interaction',
     long_description_content_type='text/markdown',


### PR DESCRIPTION
### Description:
An issue (https://github.com/bitfinexcom/bitfinex-api-py/issues/65) was raised which reports that the CPU utilization of the websocket client exceeds 100%. The problem is, that in order to keep the event emitter thread alive, the code uses a `while True` loop with `sleep(0)`.

In order to solve this issue, the event emitter thread has been set to a `daemon` thread which means it will keep alive (until the process exits) without needing an aggressive `while True` loop.

### Breaking changes:
- None

### New features:
- None

### Fixes:
- [x] Issue https://github.com/bitfinexcom/bitfinex-api-py/issues/65

### PR status:
- [x] Version bumped
- [x] Change-log updated
