### PR TITLE
adds get_ledgers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+1.1.7
+- Adds rest.get_ledgers
+
 1.1.6
 - Adds 'new_ticker' websocket event stream
 - Adds 'ws.stop' function to kill all websocket connections

--- a/bfxapi/models/__init__.py
+++ b/bfxapi/models/__init__.py
@@ -18,5 +18,6 @@ from .deposit_address import DepositAddress
 from .withdraw import Withdraw
 from .ticker import Ticker
 from .funding_ticker import FundingTicker
+from .ledger import Ledger
 
 NAME = 'models'

--- a/bfxapi/models/ledger.py
+++ b/bfxapi/models/ledger.py
@@ -7,7 +7,7 @@ class LedgerModel:
     Enum used to index the location of each value in a raw array
     """
     ID = 0
-    CURRENCY=1
+    CURRENCY = 1
     MTS = 3
     AMOUNT = 5
     BALANCE = 6
@@ -25,8 +25,6 @@ class Ledger:
     PLACEHOLDER
     DESCRIPTION
     """
-
-    # [2794967447, 'USD', None, 1588004822000, None, -8.6166026, 4299.6846957, None, 'Trading fees for 4303.997301 UST (USTUSD) @ 1.001 on BFX (0.2%) on wallet exchange'],
 
     def __init__(self, currency, mts, amount, balance, description):
         self.currency = currency
@@ -46,7 +44,7 @@ class Ledger:
         mts = raw_ledger[LedgerModel.MTS]
         amount = raw_ledger[LedgerModel.AMOUNT]
         balance = raw_ledger[LedgerModel.BALANCE]
-        description  = raw_ledger[LedgerModel.DESCRIPTION]
+        description = raw_ledger[LedgerModel.DESCRIPTION]
         return Ledger(currency, mts, amount, balance, description)
 
     def __str__(self):

--- a/bfxapi/models/ledger.py
+++ b/bfxapi/models/ledger.py
@@ -1,0 +1,56 @@
+"""
+Module used to describe a ledger object
+"""
+
+class LedgerModel:
+    """
+    Enum used to index the location of each value in a raw array
+    """
+    ID = 0
+    CURRENCY=1
+    MTS = 3
+    AMOUNT = 5
+    BALANCE = 6
+    DESCRIPTION = 8
+
+class Ledger:
+    """
+    ID int
+    CURRENCY string Currency (BTC, etc)
+    PLACEHOLDER
+    MTS	int	Millisecond Time Stamp of the update
+    PLACEHOLDER
+    AMOUNT string  Amount of funds to ledger
+    BALANCE string  Amount of funds to ledger
+    PLACEHOLDER
+    DESCRIPTION
+    """
+
+    # [2794967447, 'USD', None, 1588004822000, None, -8.6166026, 4299.6846957, None, 'Trading fees for 4303.997301 UST (USTUSD) @ 1.001 on BFX (0.2%) on wallet exchange'],
+
+    def __init__(self, currency, mts, amount, balance, description):
+        self.currency = currency
+        self.mts = mts
+        self.amount = amount
+        self.balance = balance
+        self.description = description
+
+    @staticmethod
+    def from_raw_ledger(raw_ledger):
+        """
+        Parse a raw ledger object into a Ledger object
+
+        @return Ledger
+        """
+        currency = raw_ledger[LedgerModel.CURRENCY]
+        mts = raw_ledger[LedgerModel.MTS]
+        amount = raw_ledger[LedgerModel.AMOUNT]
+        balance = raw_ledger[LedgerModel.BALANCE]
+        description  = raw_ledger[LedgerModel.DESCRIPTION]
+        return Ledger(currency, mts, amount, balance, description)
+
+    def __str__(self):
+        ''' Allow us to print the Ledger object in a pretty format '''
+        text = "Ledger <{} {} balance:{} '{}' mts={}>"
+        return text.format(self.amount, self.currency, self.balance,
+                           self.description, self.mts)

--- a/bfxapi/version.py
+++ b/bfxapi/version.py
@@ -2,4 +2,4 @@
 This module contains the current version of the bfxapi lib
 """
 
-__version__ = '1.1.6'
+__version__ = '1.1.7'


### PR DESCRIPTION
### Description:
Ledgers were missing from the REST api: https://docs.bitfinex.com/reference#rest-auth-ledgers

### Breaking changes:
- None

### New features:
- async def get_ledgers(self, symbol, start, end, limit=25, category=None):
        """
        Get all ledgers on account associated with API_KEY - Requires authentication.
        See category filters here: https://docs.bitfinex.com/reference#rest-auth-ledgers
        @return Array <models.Ledger>
        """

### Fixes:
- None

### PR status:
- [x] Version bumped
- [x] Change-log updated
