### PR TITLE
Fixed a bug. stop wasn't awaited (now it is)

### DIFF
--- a/bfxapi/websockets/generic_websocket.py
+++ b/bfxapi/websockets/generic_websocket.py
@@ -203,7 +203,7 @@ class GenericWebsocket:
         """
         This is used by the HF data server.
         """
-        self.stop()
+        await self.stop()
 
     async def on_open(self):
         """


### PR DESCRIPTION
### Description:
Found a bug when using it with the HS server.
Stop function wasn't awaited, now it is

### Fixes:
- [ ] on_close now awaits self.close

