### PR TITLE
Python 3.X compatibility

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+1.1.9
+- Updated pyee and changed deprecated class EventEmitter() -> AsyncIOEventEmitter() to make it work with all Python 3.X versions
+
 1.1.8
 - Adds support for websocket events pu, pn and pu
 

--- a/bfxapi/version.py
+++ b/bfxapi/version.py
@@ -2,4 +2,4 @@
 This module contains the current version of the bfxapi lib
 """
 
-__version__ = '1.1.7'
+__version__ = '1.1.9'

--- a/bfxapi/websockets/generic_websocket.py
+++ b/bfxapi/websockets/generic_websocket.py
@@ -3,14 +3,13 @@ Module used as a interfeace to describe a generick websocket client
 """
 
 import asyncio
-import concurrent.futures
 import websockets
 import socket
 import json
 import time
 from threading import Thread, Lock
 
-from pyee import EventEmitter
+from pyee import AsyncIOEventEmitter
 from ..utils.custom_logger import CustomLogger
 
 # websocket exceptions
@@ -57,7 +56,7 @@ class Socket():
             await self.ws.send(data)
 
 def _start_event_worker():
-    return EventEmitter(scheduler=asyncio.ensure_future)
+    return AsyncIOEventEmitter()
 
 class GenericWebsocket:
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ websockets==7.0
 pylint==2.3.0
 pytest-asyncio==0.10.0
 six==1.12.0
-pyee==7.0.1
+pyee==8.0.1
 aiohttp==3.4.4
 isort==4.3.21

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ websockets==7.0
 pylint==2.3.0
 pytest-asyncio==0.10.0
 six==1.12.0
-pyee==5.0.0
+pyee==7.0.1
 aiohttp==3.4.4
 isort==4.3.21


### PR DESCRIPTION
### Description:
bitfinex-api.py was using an old version of pyee, this did not allow the correct execution on Python 3.7 and 3.8.
I have updated pyee to last version (8.0.1) and changed the deprecated EventEmitter() with AsyncIOEventEmitter().
Now it works with all Python 3.X versions.

"On emit, the event emitter will automatically schedule the coroutine using asyncio.ensure_future and the configured event loop (defaults to asyncio.get_event_loop())." (https://pyee.readthedocs.io/en/latest/#pyee.AsyncIOEventEmitter)

### Breaking changes:
- None

### New features:
- None

### Fixes:
- Compatibility with Python 3.7 and 3.8

### PR status:
- [✔️ ] Version bumped
- [ ✔️] Change-log updated
