### PR TITLE
Use ranges in setup.py versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-eventemitter==0.2.0
 asyncio==3.4.3
 websockets==7.0
 pylint==2.3.0

--- a/setup.py
+++ b/setup.py
@@ -46,15 +46,10 @@ setup(
     python_requires='>=3.0.0, <4',
     # deps installed by pip
     install_requires=[
-        'eventemitter==0.2.0',
-        'asyncio==3.4.3',
-        'websockets==7.0',
-        'pylint==2.3.0',
-        'pytest-asyncio==0.10.0',
-        'six==1.12.0',
-        'pyee==8.0.1',
-        'aiohttp==3.4.4',
-        'isort==4.3.21'
+        'eventemitter~=0.2.0',
+        'asyncio~=3.0',
+        'websockets~=7.0',
+        'aiohttp~=3.0',
     ],
     project_urls={
         'Bug Reports': 'https://github.com/bitfinexcom/bitfinex-api-py/issues',

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         'asyncio~=3.0',
         'websockets~=7.0',
         'aiohttp~=3.0',
+        'pyee~=7.0'
     ],
     project_urls={
         'Bug Reports': 'https://github.com/bitfinexcom/bitfinex-api-py/issues',

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
         'asyncio~=3.0',
         'websockets~=7.0',
         'aiohttp~=3.0',
-        'pyee~=7.0'
+        'pyee~=8.0'
     ],
     project_urls={
         'Bug Reports': 'https://github.com/bitfinexcom/bitfinex-api-py/issues',

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ setup(
     python_requires='>=3.0.0, <4',
     # deps installed by pip
     install_requires=[
-        'eventemitter~=0.2.0',
         'asyncio~=3.0',
         'websockets~=7.0',
         'aiohttp~=3.0',


### PR DESCRIPTION
### Description:

Based in this comment thread: https://github.com/bitfinexcom/bitfinex-api-py/pull/99#discussion_r567021718
Which implemented changes in this PR: https://github.com/bitfinexcom/bitfinex-api-py/pull/88/files

Versions in setup.py shouldn't be pinned.
https://packaging.python.org/discussions/install-requires-vs-requirements/?highlight=install_requires

Removed also dev dependencies, as setup.py should only keep the ones used for production. For dev and testing you use the ones in requirements.txt.

To understand `~=` check here: https://pip.pypa.io/en/latest/user_guide/#understanding-your-error-message

>~=3.1: version 3.1 or later, but not version 4.0 or later. ~=3.1.2: version 3.1.2 or later, but not version 3.2.0 or later.

So, in sum `setup.py` should request the minimum compatible version. Or, if there are security updates, you can enforce the minimum version with the minimum security patches.

The versions, I'm not sure if they are the proper ones. Maybe they need to be tuned a bit.

Also, question: are `eventemitter` and `pyee` dependencies being used at all? I only see eventemitter used in a test. Otherwise they should be removed!

### Breaking changes:
- [ ]

### New features:
- [ ]

### Fixes:
- [ ]

### PR status:
- [ ] Version bumped
- [ ] Change-log updated
