### PR TITLE
get_seed_candles() has been fixed in a backwards compatibility manner

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+1.1.10
+- Fixed get_seed_candles() [backwards compatible]
+
 1.1.9
 - Implemented PULSE endpoints (rest)
 - Updated pyee and changed deprecated class EventEmitter() -> AsyncIOEventEmitter() to make it work with all Python 3.X versions

--- a/bfxapi/rest/bfx_rest.py
+++ b/bfxapi/rest/bfx_rest.py
@@ -6,6 +6,7 @@ import asyncio
 import aiohttp
 import time
 import json
+import datetime
 
 from ..utils.custom_logger import CustomLogger
 from ..utils.auth import generate_auth_headers, calculate_order_flags, gen_unique_cid
@@ -71,7 +72,7 @@ class BfxRest:
     #                  Public Data                   #
     ##################################################
 
-    async def get_seed_candles(self, symbol, start, end, tf='1d', limit=10000, sort=0):
+    async def get_seed_candles(self, symbol, tf='1m', start=None, end=None, limit=10000, sort=0):
         """
         Get all of the seed candles between the start and end period.
         # Attributes
@@ -84,6 +85,11 @@ class BfxRest:
         @param sort int: if = 1 it sorts results returned with old > new
         @return Array [ MTS, OPEN, CLOSE, HIGH, LOW, VOLUME ]
         """
+
+        if not start and not end:
+            start = 0
+            end = int(round((time.time() // 60 * 60) * 1000))
+
         endpoint = f'candles/trade:{tf}:{symbol}/hist?limit={limit}&start={start}&end={end}&sort={sort}'
         self.logger.info("Downloading seed candles from Bitfinex...")
         candles = await self.fetch(endpoint)

--- a/bfxapi/version.py
+++ b/bfxapi/version.py
@@ -2,4 +2,4 @@
 This module contains the current version of the bfxapi lib
 """
 
-__version__ = '1.1.9'
+__version__ = '1.1.10'


### PR DESCRIPTION
### Description:
I have re-implemented get_seed_candles() to make it consistent with the actual behaviour of the endpoint. It is no more necessary to send multiple requests and sort the result

### Breaking changes:
- No, this patch does not generate breaking changes

### New features:
- [ ]

### Fixes:
- get_seed_candles() has been fixed in a backwards compatibility manner

### PR status:
- [✔️] Version bumped
- [✔️] Change-log updated
