### PR TITLE
deleting pending orders in confirm_order_closed

### DIFF
--- a/bfxapi/websockets/order_manager.py
+++ b/bfxapi/websockets/order_manager.py
@@ -43,6 +43,8 @@ class OrderManager:
         order.set_open_state(False)
         if order.id in self.open_orders:
             del self.open_orders[order.id]
+        if order.cid in self.pending_orders:
+            del self.pending_orders[order.cid]
         self.closed_orders[order.id] = order
         if not order.is_confirmed():
             order.set_confirmed()


### PR DESCRIPTION
### Description:

If an EXCHANGE_FILL_OR_KILL order is unfilled and cancelled, `confirm_order_new` will not get called. This can leave lots of pending orders remaining in the order_manager.

However, `confirm_order_closed` will get called, and therefore we should delete pending orders from that method as well.

### Breaking changes:
- [ ]

### New features:
- [ ]

### Fixes:
- [pending orders will get deleted if they are cancelled fill or kills]

### PR status:
- [ ] Version bumped
- [ ] Change-log updated




This example can be used to reproduce the error.

```
"""
Orders remain in pending_orders after the FOKS have been cancelled.
"""
import asyncio
import sys
from bfxapi import Client, Order


bfx = Client(
  API_KEY=BITFINEX_KEY_TEST,
  API_SECRET=BITFINEX_SECRET_TEST,
  logLevel='DEBUG'
)


@bfx.ws.on('error')
def log_error(msg):
  print ("Error: {}".format(msg))


@bfx.ws.on('authenticated')
async def submit_order(auth_message):
  await asyncio.sleep(0.2)
  await bfx.ws.submit_order('tTESTBTC:TESTUSD', 1, 100, Order.Type.EXCHANGE_FILL_OR_KILL)
  await asyncio.sleep(0.01)
  await bfx.ws.submit_order('tTESTBTC:TESTUSD', 2, 50, Order.Type.EXCHANGE_FILL_OR_KILL)
  await asyncio.sleep(0.01)
  await bfx.ws.submit_order('tTESTBTC:TESTUSD', 4, 25, Order.Type.EXCHANGE_FILL_OR_KILL)

  await asyncio.sleep(1)

  print('=== Submit Order Finished ===')
  print('Pending Order Count:', len(bfx.ws.orderManager.pending_orders))
  print(bfx.ws.orderManager.pending_orders)


@bfx.ws.on('order_confirmed')
async def trade_completed(order):
  print('=== Order Confirmed ===')
  print ("Order confirmed, order_id=", order.id)
  print (order)
  print('Pending Order Count:', len(bfx.ws.orderManager.pending_orders))
  print('Pending Order Ids:', sorted(order for order in bfx.ws.orderManager.pending_orders))



bfx.ws.run()
```
