### PR TITLE
Added decorator to cache nonce and avoid race condition

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+1.1.12
+-) Added decorator to cache nonce and avoid race condition
+
 1.1.11
 -) Removed pendingOrders from BfxWebsocket() (it was not used anywhere)
 -) Fixed issue in confirm_order_new() (the keys of the dict pending_orders are the cids of the orders, and not the ids)

--- a/bfxapi/utils/auth.py
+++ b/bfxapi/utils/auth.py
@@ -6,6 +6,7 @@ to handle the http authentication of the client
 import hashlib
 import hmac
 import time
+import cachetools.func
 from ..models import Order
 
 def generate_auth_payload(API_KEY, API_SECRET):
@@ -47,6 +48,7 @@ def _gen_signature(API_KEY, API_SECRET, nonce):
 
   return authMsg, sig
 
+@cachetools.func.ttl_cache(maxsize=1, ttl=5)
 def _gen_nonce():
   return int(round(time.time() * 1000000))
 

--- a/bfxapi/version.py
+++ b/bfxapi/version.py
@@ -2,4 +2,4 @@
 This module contains the current version of the bfxapi lib
 """
 
-__version__ = '1.1.11'
+__version__ = '1.1.12'

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ six==1.12.0
 pyee==8.0.1
 aiohttp==3.4.4
 isort==4.3.21
+cachetools==4.2.1

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from os import path
 here = path.abspath(path.dirname(__file__))
 setup(
     name='bitfinex-api-py',
-    version='1.1.11',
+    version='1.1.12',
     description='Official Bitfinex Python API',
     long_description='A Python reference implementation of the Bitfinex API for both REST and websocket interaction',
     long_description_content_type='text/markdown',
@@ -51,7 +51,8 @@ setup(
         'asyncio~=3.0',
         'websockets~=7.0',
         'aiohttp~=3.0',
-        'pyee~=8.0'
+        'pyee~=8.0',
+        'cachetools~=4.0'
     ],
     project_urls={
         'Bug Reports': 'https://github.com/bitfinexcom/bitfinex-api-py/issues',


### PR DESCRIPTION
### Description:
At the moment each post method call increases the nonce, this could cause a race condition.
Several users have reported issues using our APIs for this reason.
I propose to implement a simple cache decorator to maintain the same nonce in case of multiple/parallel requests.


Example code to reproduce the issue

```
import asyncio
import sys
from bfxapi import Client, Order
import time
from datetime import datetime
import concurrent.futures

bfx = Client(
  API_KEY='',
  API_SECRET='',
  logLevel='DEBUG'
)

async def create_order():
  await bfx.rest.submit_order(amount=1, price=65432, symbol='tBTCUSD', post_only=True)
  await bfx.rest.submit_order(amount=1, price=65432, symbol='tBTCUSD', post_only=True)
  await bfx.rest.submit_order(amount=1, price=65432, symbol='tBTCUSD', post_only=True)
  await bfx.rest.submit_order(amount=1, price=65432, symbol='tBTCUSD', post_only=True)
  await bfx.rest.submit_order(amount=1, price=65432, symbol='tBTCUSD', post_only=True)
  await bfx.rest.submit_order(amount=1, price=65432, symbol='tBTCUSD', post_only=True)
  await bfx.rest.submit_order(amount=1, price=65432, symbol='tBTCUSD', post_only=True)
  await bfx.rest.submit_order(amount=1, price=65432, symbol='tBTCUSD', post_only=True)

loop = asyncio.get_event_loop()
loop.run_until_complete(asyncio.gather(
    create_order(),
    create_order(),
    create_order(),
    create_order(),
    create_order(),
    create_order(),
    create_order()
))

loop.close()
```

Error

`bitfinex.rest.restv2.BitfinexException: (500, 'Internal Server Error', ['error', 10114, 'nonce: small'])`


### Breaking changes:
- [ ]

### New features:
- [ ]

### Fixes:
- [X]

With this PR the example code above runs smoothly

### PR status:
- [X] Version bumped
- [X] Change-log updated
