### PR TITLE
Invalid orders should be removed from pending_orders

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 1.1.12
 -) Invalid orders are now removed from pending_orders
+-) FOK orders cancelled are now removed from pending_orders
 
 1.1.11
 -) Removed pendingOrders from BfxWebsocket() (it was not used anywhere)

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+1.1.12
+-) Invalid orders are now removed from pending_orders
+
 1.1.11
 -) Removed pendingOrders from BfxWebsocket() (it was not used anywhere)
 -) Fixed issue in confirm_order_new() (the keys of the dict pending_orders are the cids of the orders, and not the ids)

--- a/bfxapi/version.py
+++ b/bfxapi/version.py
@@ -2,4 +2,4 @@
 This module contains the current version of the bfxapi lib
 """
 
-__version__ = '1.1.11'
+__version__ = '1.1.12'

--- a/bfxapi/websockets/bfx_websocket.py
+++ b/bfxapi/websockets/bfx_websocket.py
@@ -314,6 +314,7 @@ class BfxWebsocket(GenericWebsocket):
         notificationText = nInfo[7]
         if notificationType == 'ERROR':
             # self._emit('error', notificationText)
+            await self._order_error_handler(data)
             self.logger.error(
                 "Notification ERROR: {}".format(notificationText))
         else:
@@ -326,6 +327,9 @@ class BfxWebsocket(GenericWebsocket):
 
     async def _order_closed_handler(self, data):
         await self.orderManager.confirm_order_closed(data)
+
+    async def _order_error_handler(self, data):
+        await self.orderManager.confirm_order_error(data)
 
     async def _order_update_handler(self, data):
         await self.orderManager.confirm_order_update(data)

--- a/bfxapi/websockets/order_manager.py
+++ b/bfxapi/websockets/order_manager.py
@@ -43,6 +43,8 @@ class OrderManager:
         order.set_open_state(False)
         if order.id in self.open_orders:
             del self.open_orders[order.id]
+        if order.cid in self.pending_orders:
+            del self.pending_orders[order.cid]
         self.closed_orders[order.id] = order
         if not order.is_confirmed():
             order.set_confirmed()

--- a/bfxapi/websockets/order_manager.py
+++ b/bfxapi/websockets/order_manager.py
@@ -87,6 +87,12 @@ class OrderManager:
         self.logger.info("Order new: {}".format(order))
         self.bfxapi._emit('order_new', order)
 
+    async def confirm_order_error(self, raw_ws_data):
+        cid = raw_ws_data[2][4][2]
+        if cid in self.pending_orders:
+            del self.pending_orders[cid]
+        self.logger.info("Deleted Order CID {} from pending orders".format(cid))
+
     async def submit_order(self, symbol, price, amount, market_type=Order.Type.LIMIT,
                            hidden=False, price_trailing=None, price_aux_limit=None,
                            oco_stop_price=None, close=False, reduce_only=False,


### PR DESCRIPTION
### Description:
Please see https://github.com/bitfinexcom/bitfinex-api-py/issues/123

If an invalid order is submitted, it is now removed from pending_orders.


```
[BfxOrderManager] [INFO] Order cid=1617705257122 (tBTCUSD -25 @ 4) dispatched
[BfxWebsocket] [DEBUG] [0,"n",[1617705257166,"on-req",null,null,[null,null,1617705257122,"tBTCUSD",null,null,-25,null,"EXCHANGE LIMIT",null,null,null,0,null,null,null,4,null,0,0,null,null,null,0,0,null,null,null,null,null,null,{}],null,"ERROR","Invalid order: not enough exchange balance for -25 BTCUSD at 4"]]
[BfxOrderManager] [INFO] Deleted Order CID 1617705257122 from pending orders
[BfxWebsocket] [ERROR] Notification ERROR: Invalid order: not enough exchange balance for -25 BTCUSD at 4
```


If an EXCHANGE_FILL_OR_KILL order is unfilled and cancelled it is now removed from pending orders.


### Breaking changes:
- [ ]

### New features:
- [ ]

### Fixes:
- [X]

### PR status:
- [X] Version bumped
- [X] Change-log updated
