### PR TITLE
get_public_trades() orders should be sorted by [timestamp, id]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+1.1.12
+-) Applied clientside fix to get_public_trades() (in case of multiple trades at the same timestamp they should be ordered by id)
+
 1.1.11
 -) Removed pendingOrders from BfxWebsocket() (it was not used anywhere)
 -) Fixed issue in confirm_order_new() (the keys of the dict pending_orders are the cids of the orders, and not the ids)

--- a/bfxapi/rest/bfx_rest.py
+++ b/bfxapi/rest/bfx_rest.py
@@ -133,7 +133,7 @@ class BfxRest:
         params = "?start={}&end={}&limit={}&sort={}".format(
             start, end, limit, sort)
         trades = await self.fetch(endpoint, params=params)
-        return trades
+        return sorted(trades, key=lambda x: (x[1], x[0]), reverse=True if sort == 1 else False)
 
     async def get_public_books(self, symbol, precision="P0", length=25):
         """

--- a/bfxapi/tests/test_rest_get_public_trades.py
+++ b/bfxapi/tests/test_rest_get_public_trades.py
@@ -1,0 +1,36 @@
+import asyncio
+import concurrent.futures
+from bfxapi import Client
+
+bfx = Client(logLevel='DEBUG')
+
+async def run():
+    start = 1617519600000
+    candles = await bfx.rest.get_public_candles(start=start, symbol='tBTCUSD', end=None, tf='1h', sort=1, limit=1)
+    candle = candles[0]
+    price = candle[1]
+    assert price == 57394.61698309
+
+    orders_ids = []
+    trades = await bfx.rest.get_public_trades(start=1617519600000, limit=5, symbol='tBTCUSD', end=None, sort=1)
+    print(trades)
+    for trade in trades:
+        orders_ids.append(trade[0])
+    assert orders_ids == [657815316, 657815314, 657815312, 657815311, 657815309]
+
+    # check that strictly decreasing order id condition is always respected
+    # check that not increasing timestamp condition is always respected
+    orders_ids = []
+    timestamps = []
+    trades = await bfx.rest.get_public_trades(start=1617519600000, limit=5000, symbol='tLEOUSD', end=None, sort=1)
+    print(trades)
+    for trade in trades:
+        orders_ids.append(trade[0])
+        timestamps.append(trade[1])
+
+    assert not all(x > y for x, y in zip(orders_ids, orders_ids[1:])) is False
+    assert not all(x >= y for x, y in zip(orders_ids, orders_ids[1:])) is False
+
+def test_get_public_trades():
+    t = asyncio.ensure_future(run())
+    asyncio.get_event_loop().run_until_complete(t)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from os import path
 here = path.abspath(path.dirname(__file__))
 setup(
     name='bitfinex-api-py',
-    version='1.1.11',
+    version='1.1.12',
     description='Official Bitfinex Python API',
     long_description='A Python reference implementation of the Bitfinex API for both REST and websocket interaction',
     long_description_content_type='text/markdown',


### PR DESCRIPTION
### Description:

#When using get_public_trades with sort=1, the orders are not sorted properly whenever there are multiple trades occurring at the same time. I've sent this issue to your support team a while ago but it would be nice to have a fix on the interface level as well.

Please see full issue thread here -> https://github.com/bitfinexcom/bitfinex-api-py/issues/124

### Breaking changes:
- [ ]

### New features:
- [ ]

### Fixes:
- [X]

### PR status:
- [X] Version bumped
- [X] Change-log updated
