### PR TITLE
fix: wrong value format in definition

### DIFF
--- a/bfxapi/rest/bfx_rest.py
+++ b/bfxapi/rest/bfx_rest.py
@@ -97,7 +97,7 @@ class BfxRest:
         return candles
 
     async def get_public_candles(self, symbol, start, end, section='hist',
-                                 tf='1m', limit="100", sort=-1):
+                                 tf='1m', limit=100, sort=-1):
         """
         Get all of the public candles between the start and end period.
 
@@ -118,7 +118,7 @@ class BfxRest:
         candles = await self.fetch(endpoint, params=params)
         return candles
 
-    async def get_public_trades(self, symbol, start, end, limit="100", sort=-1):
+    async def get_public_trades(self, symbol, start, end, limit=100, sort=-1):
         """
         Get all of the public trades between the start and end period.
 


### PR DESCRIPTION
get_public_candles (line 99) : limit arg was set as string while below it is defined as int
get_public_trades (line 121) : limit arg was set as string while below it is defined as int

### Description:
updated definitions: wrong value format given for arguments in definition.

### Breaking changes:
- [ ]

### New features:
- [ ]

### Fixes:
- [x] get_public_candles (line 99)
- [x] get_public_trades (line 121)

### PR status:
- [ ] Version bumped
- [ ] Change-log updated
