### PR TITLE
Added missing error to ERRORS

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+1.1.14
+-) bfx_websockets.py ERRORS dictionary now contains a message for error number 10305
+
 1.1.13
 -) Adding balance_available to the Wallet.
 

--- a/bfxapi/version.py
+++ b/bfxapi/version.py
@@ -2,4 +2,4 @@
 This module contains the current version of the bfxapi lib
 """
 
-__version__ = '1.1.13'
+__version__ = '1.1.14'

--- a/bfxapi/websockets/bfx_websocket.py
+++ b/bfxapi/websockets/bfx_websocket.py
@@ -96,6 +96,7 @@ ERRORS = {
     10200: 'Error in un-authentication request',
     10300: 'Subscription Failed (generic)',
     10301: 'Already Subscribed',
+    10305: 'Reached limit of open channels',
     10302: 'Unknown channel',
     10400: 'Subscription Failed (generic)',
     10401: 'Not subscribed',


### PR DESCRIPTION
### Description:
bfx_websockets.py ERRORS dictionary now contains a message for error number 10305

### Breaking changes:
- [ ]

### New features:
- [ ]

### Fixes:
- [X]

### PR status:
- [X] Version bumped
- [X] Change-log updated
