### PR TITLE
(issue - #146) Account's trade execution (te) and trade update (tu) handling

### DIFF
--- a/bfxapi/websockets/bfx_websocket.py
+++ b/bfxapi/websockets/bfx_websocket.py
@@ -2,17 +2,14 @@
 Module used to house the bitfine websocket client
 """
 
-import asyncio
 import json
-import time
-import random
 
 from .generic_websocket import GenericWebsocket, AuthError
+from .order_manager import OrderManager
 from .subscription_manager import SubscriptionManager
 from .wallet_manager import WalletManager
-from .order_manager import OrderManager
+from ..models import OrderBook, Ticker, FundingTicker
 from ..utils.auth import generate_auth_payload
-from ..models import Order, Trade, OrderBook, Ticker, FundingTicker
 
 
 class Flags:
@@ -63,6 +60,37 @@ def _parse_trade(tData, symbol):
         'price': tData[3],
         'amount': tData[2],
         'symbol': symbol
+    }
+
+def _parse_account_trade(tData):
+    return {
+        'id': tData[0],
+        'symbol': tData[1],
+        'mts_create': tData[2],
+        'order_id': tData[3],
+        'exec_amount': tData[4],
+        'exec_price': tData[5],
+        'order_type': tData[6],
+        'order_price': tData[7],
+        'maker': tData[8],
+        'cid': tData[11],
+    }
+
+
+def _parse_account_trade_update(tData):
+    return {
+        'id': tData[0],
+        'symbol': tData[1],
+        'mts_create': tData[2],
+        'order_id': tData[3],
+        'exec_amount': tData[4],
+        'exec_price': tData[5],
+        'order_type': tData[6],
+        'order_price': tData[7],
+        'maker': tData[8],
+        'fee': tData[9],
+        'fee_currency': tData[10],
+        'cid': tData[11],
     }
 
 def _parse_deriv_status_update(sData, symbol):
@@ -277,19 +305,15 @@ class BfxWebsocket(GenericWebsocket):
 
     async def _trade_update_handler(self, data):
         tData = data[2]
-        # [209, 'tu', [312372989, 1542303108930, 0.35, 5688.61834032]]
-        if self.subscriptionManager.is_subscribed(data[0]):
-            symbol = self.subscriptionManager.get(data[0]).symbol
-            tradeObj = _parse_trade(tData, symbol)
-            self._emit('trade_update', tradeObj)
+        # [0,"tu",[738045455,"tTESTBTC:TESTUSD",1622169615771,66635385225,0.001,38175,"EXCHANGE LIMIT",39000,-1,-0.000002,"TESTBTC",1622169615685]]
+        tradeObj = _parse_account_trade_update(tData)
+        self._emit('trade_update', tradeObj)
 
     async def _trade_executed_handler(self, data):
         tData = data[2]
-        # [209, 'te', [312372989, 1542303108930, 0.35, 5688.61834032]]
-        if self.subscriptionManager.is_subscribed(data[0]):
-            symbol = self.subscriptionManager.get(data[0]).symbol
-            tradeObj = _parse_trade(tData, symbol)
-            self._emit('new_trade', tradeObj)
+        # [0,"te",[738045455,"tTESTBTC:TESTUSD",1622169615771,66635385225,0.001,38175,"EXCHANGE LIMIT",39000,-1,null,null,1622169615685]]
+        tradeObj = _parse_account_trade(tData)
+        self._emit('new_trade', tradeObj)
 
     async def _wallet_update_handler(self, data):
         # [0,"wu",["exchange","USD",89134.66933283,0]]
@@ -408,12 +432,8 @@ class BfxWebsocket(GenericWebsocket):
             # connection
             data.reverse()
             for t in data:
-                trade = {
-                    'mts': t[1],
-                    'amount': t[2],
-                    'price': t[3],
-                    'symbol': symbol
-                }
+                trade = _parse_trade(t, symbol)
+
                 self._emit('seed_trade', trade)
 
     async def _candle_handler(self, data):


### PR DESCRIPTION
### Description:
The trade (te) and trade update (tu) of user's account is not handling well.

It should already be subscribed and sent through chanId 0 ( so subscription should be checked )
More additional information can be received from account's trade, the parser is enriched.

### Breaking changes:
- [ ]

### New features:
- [ ] parsing account's trade execution and trade update

### Fixes:
- [ ]

### PR status:
- [ ] Version bumped
- [ ] Change-log updated
