### PR TITLE
Deprecate BfxRest loop kwarg and attribute

### DIFF
--- a/bfxapi/rest/bfx_rest.py
+++ b/bfxapi/rest/bfx_rest.py
@@ -24,13 +24,25 @@ class BfxRest:
 
     def __init__(self, API_KEY, API_SECRET, host='https://api-pub.bitfinex.com/v2', loop=None,
                  logLevel='INFO', parse_float=float, *args, **kwargs):
-        self.loop = loop or asyncio.get_event_loop()
+        if loop is not None:
+            warnings.warn(
+                "The loop argument is deprecated because it is unused",
+                DeprecationWarning,
+            )
         self.API_KEY = API_KEY
         self.API_SECRET = API_SECRET
         self.host = host
         # this value can also be set to bfxapi.decimal for much higher precision
         self.parse_float = parse_float
         self.logger = CustomLogger('BfxRest', logLevel=logLevel)
+        
+    @property
+    def loop(self):
+        warnings.warn(
+            "The BfxRest.loop attribute is deprecated use asyncio.get_running_loop",
+            DeprecationWarning,
+        )
+        return asyncio.get_running_loop()
 
     async def fetch(self, endpoint, params=""):
         """

--- a/bfxapi/rest/bfx_rest.py
+++ b/bfxapi/rest/bfx_rest.py
@@ -7,6 +7,7 @@ import aiohttp
 import time
 import json
 import datetime
+import warnings
 
 from ..utils.custom_logger import CustomLogger
 from ..utils.auth import generate_auth_headers, calculate_order_flags, gen_unique_cid


### PR DESCRIPTION
> Deprecated since version 3.10: Deprecation warning is emitted if there is no running event loop. If future Python releases this function will be an alias of get_running_loop().

https://docs.python.org/3.11/library/asyncio-eventloop.html#asyncio.get_event_loop

### Description:
to avoid use of deprecated asyncio.get_event_loop()

### Breaking changes:
- [ ]

### New features:
- [ ]

### Fixes:
- [ ]

### PR status:
- [ ] Version bumped
- [ ] Change-log updated
