### PR TITLE
Fixed a bug in 'close position' flag

### DIFF
--- a/bfxapi/models/order.py
+++ b/bfxapi/models/order.py
@@ -67,7 +67,7 @@ class OrderFlags:
     as flags
     """
     HIDDEN = 64
-    CLOSE = 12
+    CLOSE = 512
     REDUCE_ONLY = 1024
     POST_ONLY = 4096
     OCO = 16384


### PR DESCRIPTION
 Flag "close=True" in order didn't work (when size of open position was less than min order size) due to typo in close flag value. 
Changed value to 512 in accordance with https://docs.bitfinex.com/docs/flag-values.