### PR TITLE
Fixed bug in setting 'time in force' in order update

### DIFF
--- a/bfxapi/rest/bfx_rest.py
+++ b/bfxapi/rest/bfx_rest.py
@@ -869,7 +869,7 @@ class BfxRest:
         if price_trailing != None:
             payload['price_trailing'] = str(price_trailing)
         if time_in_force != None:
-            payload['time_in_force'] = str(time_in_force)
+            payload['tif'] = str(time_in_force)
         if leverage != None:
             payload["lev"] = str(leverage)
         flags = calculate_order_flags(

--- a/bfxapi/websockets/order_manager.py
+++ b/bfxapi/websockets/order_manager.py
@@ -202,7 +202,7 @@ class OrderManager:
         if price_trailing != None:
             payload['price_trailing'] = str(price_trailing)
         if time_in_force != None:
-            payload['time_in_force'] = str(time_in_force)
+            payload['tif'] = str(time_in_force)
         if leverage != None:
             payload['lev'] = str(leverage)
         flags = calculate_order_flags(


### PR DESCRIPTION
It was impossible to set up 'time in force' during order update because of irrelevant key name in payload( 'time_in_force' instead of 'tif'). Changed key name to 'tif' in update_order func (like implemented in submit_order func).