### PR TITLE
Price not anymore required in submit_order()

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+1.2.4
+-) Price is not anymore required in submit_order() as it can be None if market_type=OrderType.MARKET
+
 1.2.3
 -) Tests adjusted
 

--- a/bfxapi/examples/rest/create_order.py
+++ b/bfxapi/examples/rest/create_order.py
@@ -15,7 +15,7 @@ bfx = Client(
 )
 
 async def create_order():
-  response = await bfx.rest.submit_order("tBTCUSD", 10, 0.1)
+  response = await bfx.rest.submit_order(symbol="tBTCUSD", amount=10, price=0.1)
   # response is in the form of a Notification object
   for o in response.notify_info:
     # each item is in the form of an Order object

--- a/bfxapi/examples/ws/send_order.py
+++ b/bfxapi/examples/ws/send_order.py
@@ -34,7 +34,7 @@ def log_error(msg):
 
 @bfx.ws.on('authenticated')
 async def submit_order(auth_message):
-  await bfx.ws.submit_order('tBTCUSD', 19000, 0.01, Order.Type.EXCHANGE_MARKET)
+  await bfx.ws.submit_order(symbol='tBTCUSD', price=None, amount=0.01, market_type=Order.Type.EXCHANGE_MARKET)
 
 # If you dont want to use a decorator
 # ws.on('authenticated', submit_order)

--- a/bfxapi/rest/bfx_rest.py
+++ b/bfxapi/rest/bfx_rest.py
@@ -732,7 +732,7 @@ class BfxRest:
     #                    Orders                      #
     ##################################################
 
-    async def submit_order(self, symbol, price, amount, market_type=Order.Type.LIMIT,
+    async def submit_order(self, symbol, amount, price=None, market_type=Order.Type.LIMIT,
                            hidden=False, price_trailing=None, price_aux_limit=None,
                            oco_stop_price=None, close=False, reduce_only=False,
                            post_only=False, oco=False, aff_code=None, time_in_force=None,

--- a/bfxapi/tests/test_ws_orders.py
+++ b/bfxapi/tests/test_ws_orders.py
@@ -12,7 +12,7 @@ async def test_submit_order():
 	## send auth accepted
 	await ws_publish_auth_accepted(client.ws)
 	## send new order
-	await client.ws.submit_order('tBTCUSD', 19000, 0.01, 'EXCHANGE MARKET')
+	await client.ws.submit_order(symbol='tBTCUSD', price=19000, amount=0.01, market_type='EXCHANGE MARKET')
 	last_sent = client.ws.get_last_sent_item()
 	sent_order_array = json.loads(last_sent['data'])
 	assert sent_order_array[1] == "on"
@@ -123,7 +123,7 @@ async def test_closed_callback_on_submit_order_closed():
 	callback_wait = EventWatcher.watch(client.ws, 'c1')
 	# override cid generation
 	client.ws.orderManager._gen_unique_cid = lambda: 123
-	await client.ws.submit_order('tBTCUSD', 19000, 0.01, 'EXCHANGE MARKET', onClose=c)
+	await client.ws.submit_order(symbol='tBTCUSD', price=19000, amount=0.01, market_type='EXCHANGE MARKET', onClose=c)
 	await client.ws.publish([0,"oc",[123,None,1548262833910,"tBTCUSD",1548262833379,1548262888016,0,-1,"EXCHANGE LIMIT",None,None,None,0,"EXECUTED @ 15980.0(-0.5): was PARTIALLY FILLED @ 15980.0(-0.5)",None,None,15980,15980,0,0,None,None,None,0,0,None,None,None,"API>BFX",None,None,None]])
 	callback_wait.wait_until_complete()
 
@@ -140,7 +140,7 @@ async def test_confirmed_callback_on_submit_order_closed():
 	callback_wait = EventWatcher.watch(client.ws, 'c1')
 	# override cid generation
 	client.ws.orderManager._gen_unique_cid = lambda: 123
-	await client.ws.submit_order('tBTCUSD', 19000, 0.01, 'EXCHANGE MARKET', onConfirm=c)
+	await client.ws.submit_order(symbol='tBTCUSD', price=19000, amount=0.01, market_type='EXCHANGE MARKET', onConfirm=c)
 	await client.ws.publish([0,"oc",[123,None,1548262833910,"tBTCUSD",1548262833379,1548262888016,0,-1,"EXCHANGE LIMIT",None,None,None,0,"EXECUTED @ 15980.0(-0.5): was PARTIALLY FILLED @ 15980.0(-0.5)",None,None,15980,15980,0,0,None,None,None,0,0,None,None,None,"API>BFX",None,None,None]])
 	callback_wait.wait_until_complete()
 
@@ -156,7 +156,7 @@ async def test_confirmed_callback_on_submit_new_order():
 	callback_wait = EventWatcher.watch(client.ws, 'c1')
 	# override cid generation
 	client.ws.orderManager._gen_unique_cid = lambda: 123
-	await client.ws.submit_order('tBTCUSD', 19000, 0.01, 'EXCHANGE MARKET', onConfirm=c)
+	await client.ws.submit_order(symbol='tBTCUSD', price=19000, amount=0.01, market_type='EXCHANGE MARKET', onConfirm=c)
 	await client.ws.publish([0,"on",[123,None,1548262833910,"tBTCUSD",1548262833379,1548262833410,-1,-1,"EXCHANGE LIMIT",None,None,None,0,"ACTIVE",None,None,15980,0,0,0,None,None,None,0,0,None,None,None,"API>BFX",None,None,None]])
 	callback_wait.wait_until_complete()
 

--- a/bfxapi/version.py
+++ b/bfxapi/version.py
@@ -2,4 +2,4 @@
 This module contains the current version of the bfxapi lib
 """
 
-__version__ = '1.2.3'
+__version__ = '1.2.4'

--- a/bfxapi/websockets/order_manager.py
+++ b/bfxapi/websockets/order_manager.py
@@ -95,7 +95,7 @@ class OrderManager:
             del self.pending_orders[cid]
         self.logger.info("Deleted Order CID {} from pending orders".format(cid))
 
-    async def submit_order(self, symbol, price, amount, market_type=Order.Type.LIMIT,
+    async def submit_order(self, symbol, amount, price=None, market_type=Order.Type.LIMIT,
                            hidden=False, price_trailing=None, price_aux_limit=None,
                            oco_stop_price=None, close=False, reduce_only=False,
                            post_only=False, oco=False, aff_code=None, time_in_force=None,


### PR DESCRIPTION
### Description:
Price should not be required in submit_order() as it can be None if market_type=OrderType.MARKET.
It is possible to pass price=None as a workaround but I think it's better to apply the changes of this PR.

Issue: https://github.com/bitfinexcom/bitfinex-api-py/issues/171

### Breaking changes:
- [ ]

### New features:
- [ ]

### Fixes:
- [X]

### PR status:
- [X] Version bumped
- [X] Change-log updated
