### PR TITLE
Bugfix - It is now possible to call bfx.ws.run() from an already running event loop

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+1.2.8
+-) Bugfix - It is possible to call bfx.ws.run() from an already running event loop
+
 1.2.7
 -) Added ws support for Python 3.9 and 3.10
 

--- a/bfxapi/version.py
+++ b/bfxapi/version.py
@@ -2,4 +2,4 @@
 This module contains the current version of the bfxapi lib
 """
 
-__version__ = '1.2.7'
+__version__ = '1.2.8'

--- a/bfxapi/websockets/generic_websocket.py
+++ b/bfxapi/websockets/generic_websocket.py
@@ -84,8 +84,10 @@ class GenericWebsocket:
         thread and connection.
         """
         self._start_new_socket()
-        while True:
-            time.sleep(1)
+        event_loop = asyncio.get_event_loop()
+        if not event_loop or not event_loop.is_running():
+            while True:
+                time.sleep(1)
 
     def get_task_executable(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from os import path
 here = path.abspath(path.dirname(__file__))
 setup(
     name='bitfinex-api-py',
-    version='1.2.7',
+    version='1.2.8',
     description='Official Bitfinex Python API',
     long_description='A Python reference implementation of the Bitfinex API for both REST and websocket interaction',
     long_description_content_type='text/markdown',


### PR DESCRIPTION
### Description:
A user reported that calling self.bfx.ws.run() from an async function freezes the execution of the program due to the while loop (https://github.com/bitfinexcom/bitfinex-api-py/pull/182/files#diff-5a4859241d03c91d234e0858da6b2ec849b490b086a33e1201a9ab861067e191R90), but the latter is necessary when you call bfx.ws.run() [in this other way.](https://github.com/bitfinexcom/bitfinex-api-py/blob/master/bfxapi/examples/ws/update_order.py#L41)

### Breaking changes:
- [ ]

### New features:
- [ ]

### Fixes:
- [X]

### PR status:
- [X] Version bumped
- [X] Change-log updated
