### PR TITLE
Fixed socket.send() issue (IndexError: deque index out of range)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+1.3.3
+-) Fixed socket.send() issue (IndexError: deque index out of range)
+
 1.3.2
 -) Implemented Merchants endpoints (REST)
 

--- a/bfxapi/utils/decorators.py
+++ b/bfxapi/utils/decorators.py
@@ -2,10 +2,10 @@ from ..utils.custom_logger import CustomLogger
 
 
 def handle_failure(func):
-    def inner_function(*args, **kwargs):
+    async def inner_function(*args, **kwargs):
         logger = CustomLogger('BfxWebsocket', logLevel="DEBUG")
         try:
-            func(*args, **kwargs)
+            await func(*args, **kwargs)
         except Exception as exception_message:
             logger.error(exception_message)
 

--- a/bfxapi/utils/decorators.py
+++ b/bfxapi/utils/decorators.py
@@ -1,0 +1,12 @@
+from ..utils.custom_logger import CustomLogger
+
+
+def handle_failure(func):
+    def inner_function(*args, **kwargs):
+        logger = CustomLogger('BfxWebsocket', logLevel="DEBUG")
+        try:
+            func(*args, **kwargs)
+        except Exception as exception_message:
+            logger.error(exception_message)
+
+    return inner_function

--- a/bfxapi/version.py
+++ b/bfxapi/version.py
@@ -2,4 +2,4 @@
 This module contains the current version of the bfxapi lib
 """
 
-__version__ = '1.3.2'
+__version__ = '1.3.3'

--- a/bfxapi/websockets/bfx_websocket.py
+++ b/bfxapi/websockets/bfx_websocket.py
@@ -12,6 +12,7 @@ from .subscription_manager import SubscriptionManager
 from .wallet_manager import WalletManager
 from .order_manager import OrderManager
 from ..utils.auth import generate_auth_payload
+from ..utils.decorators import handle_failure
 from ..models import Order, Trade, OrderBook, Ticker, FundingTicker
 
 
@@ -481,6 +482,7 @@ class BfxWebsocket(GenericWebsocket):
         else:
             self.logger.warn('Unknown (socketId={}) websocket response: {}'.format(socketId, msg))
 
+    @handle_failure
     async def _ws_authenticate_socket(self, socketId):
         socket = self.sockets[socketId]
         socket.set_authenticated()
@@ -507,6 +509,7 @@ class BfxWebsocket(GenericWebsocket):
         # re-subscribe to existing channels
         await self.subscriptionManager.resubscribe_by_socket(socket_id)
 
+    @handle_failure
     async def _send_auth_command(self, channel_name, data):
         payload = [0, channel_name, None, data]
         socket = self.get_authenticated_socket()
@@ -538,6 +541,7 @@ class BfxWebsocket(GenericWebsocket):
             total += self.get_socket_capacity(socketId)
         return total
 
+    @handle_failure
     async def enable_flag(self, flag):
         """
         Enable flag on websocket connection

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from os import path
 here = path.abspath(path.dirname(__file__))
 setup(
     name='bitfinex-api-py',
-    version='1.3.2',
+    version='1.3.3',
     description='Official Bitfinex Python API',
     long_description='A Python reference implementation of the Bitfinex API for both REST and websocket interaction',
     long_description_content_type='text/markdown',


### PR DESCRIPTION
### Description:
This fixes the following error

```
Fatal error on SSL transport
protocol: <asyncio.sslproto.SSLProtocol object at 0x10202c5e0>
transport: <_SelectorSocketTransport fd=18 read=polling write=<idle, bufsize=0>>
Traceback (most recent call last):
  File "/Users/mkml/.pyenv/versions/3.9.5/lib/python3.9/asyncio/sslproto.py", line 672, in _process_write_backlog
    data, offset = self._write_backlog[0]
IndexError: deque index out of range
socket.send() raised exception.
Error in data transfer
RuntimeError: cannot schedule new futures after shutdown
```

### Breaking changes:
- [ ]

### New features:
- [ ]

### Fixes:
- [x]

### PR status:
- [x] Version bumped
- [x] Change-log updated
