### PR TITLE
iterate does not work anymore, is_iterable should be used

### DIFF
--- a/bfxapi/websocket/handlers/authenticated_channels_handler.py
+++ b/bfxapi/websocket/handlers/authenticated_channels_handler.py
@@ -61,7 +61,7 @@ class AuthenticatedChannelsHandler:
             event, serializer = f"{stream[1]}-notification", _Notification(serializer=serializers.Order)
 
         if stream[1] == "oc_multi-req":
-            event, serializer = f"{stream[1]}-notification", _Notification(serializer=serializers.Order, iterate=True)
+            event, serializer = f"{stream[1]}-notification", _Notification(serializer=serializers.Order, is_iterable=True)
 
         if stream[1] == "fon-req" or stream[1] == "foc-req":
             event, serializer = f"{stream[1]}-notification", _Notification(serializer=serializers.FundingOffer)


### PR DESCRIPTION
# Description
A wrong parameter name is used

## Motivation and Context
oc multi order notifications cannot be processed otherwise

PR fixes the following issue: 
I replace **iterate** with **is_iterable**

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue);
- [ ] New feature (non-breaking change which adds functionality);
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected);
- [ ] This change requires a documentation update;

# Checklist:

- [x] My code follows the style guidelines of this project;
- [x] I have performed a self-review of my code;
- [] I have commented my code, particularly in hard-to-understand areas;
- [] I have made corresponding changes to the documentation;
- [x] My changes generate no new warnings;
- [] I have added tests that prove my fix is effective or that my feature works;
- [] New and existing unit tests pass locally with my changes;
- [] Mypy returns no errors or warnings when run on the root package;
- [] Pylint returns a score of 10.00/10.00 when run on the root package;
- [] I have updated the library version and updated the CHANGELOG;