### PR TITLE
Support urllib3 <2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup(
         "pyee~=11.1.0",
         "websockets~=12.0",
         "requests~=2.32.3",
-        "types-requests~=2.31.0.10",
         "types-urllib3~=1.26.25.14",
     ],
     python_requires=">=3.8",


### PR DESCRIPTION
# Description
`types-requests~=2.31.0.10` in `setup.py` causes this package to be in conflict with packages that require `urllib3 < 2`, even though `requests` package support this `urllib3` version. `types-requests` is development only package and as such doesn't need to be installed.

## Motivation and Context
Could not install `vcrpy` along with this package.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue);

# Checklist:

- [x] I've done a self-review of my code;
- [x] I've made sure my changes generate no warnings;
- [x] mypy returns no errors when run on the root package;

